### PR TITLE
Update deprecated dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-PyJWT
+PyJWT==2.10.1
 google-auth
 requests
-werkzeug>=0.15.3
-Flask==2.3.2
-requests-toolbelt==0.7.1
-boto3==1.4.7
+werkzeug>=3.0.0,<4.0.0
+Flask==3.1.1
+requests-toolbelt==1.0.0
+boto3==1.38.21
 
 # Only if using flex
-gunicorn==19.9.0
+gunicorn==23.0.0


### PR DESCRIPTION
This commit updates the following Python packages to their latest stable versions:
- PyJWT to 2.10.1
- Flask to 3.1.1
- Werkzeug to >=3.0.0,<4.0.0 (compatible with Flask 3.1.1)
- requests-toolbelt to 1.0.0
- boto3 to 1.38.21
- gunicorn to 23.0.0 (for App Engine Flex)

The versions for google-auth and requests were kept as is, as they were not reported as outdated for these specific updates.

No automated test suite was found in the repository. Manual verification may be needed to ensure application functionality after these dependency updates.